### PR TITLE
Set permissions explicitly for entrypoint

### DIFF
--- a/ros-base/Dockerfile
+++ b/ros-base/Dockerfile
@@ -44,5 +44,7 @@ RUN source /opt/ros/${ROS_DISTRO}/setup.bash \
 RUN echo "source /ros_entrypoint.sh" >> /root/.bashrc
 
 COPY ./ros_catkin_entrypoint.sh /
+RUN chmod +x /ros_catkin_entrypoint.sh
+
 ENTRYPOINT ["/ros_catkin_entrypoint.sh"]
 CMD ["bash"]


### PR DESCRIPTION
Set the executable bit explicitly for `/ros_catkin_entrypoint.sh`. Why? 

If the docker build context resides in a Windows file system, every file in the build context gets '`rwxr-xr-x` set by default since Windows doesn't have an executable permission equivalent. 

If the docker build context is in a Linux file system, it needs to be set as executable explicitly. Either by having the script file commited to git with the correct permission or by setting it in the Dockerfile. Setting it in the dockerfile seems to me to be the more transparent option.