### PR TITLE
Update premake.sh

### DIFF
--- a/examples/moveit-dev/scripts/premake.sh
+++ b/examples/moveit-dev/scripts/premake.sh
@@ -10,5 +10,13 @@ if [ ! -d "$CATKIN_WS/src/universal_robot" ]; then
   git clone -b ${ROS_DISTRO}-devel https://github.com/ros-industrial/universal_robot.git
 fi
 
+# Fix ros apt-key to prevent apt-install errors.
+# Note: See https://github.com/osrf/docker_images/issues/535#issuecomment-851505821
+# NOTE: Needed because of this bug https://github.com/osrf/docker_images/issues/535
+apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+
+# update apt sources to apply the fix
+apt-get update
+
 # Install dependencies
 apt-get install -y ros-${ROS_DISTRO}-joint-state-publisher ros-${ROS_DISTRO}-industrial-core


### PR DESCRIPTION
Add a (temporal) fix on the apt keys to make apt-install work without errors while installing dependencies. This can lead i.e. to ERROR: cannot launch node of type [joint_state_publisher/joint_state_publisher]: joint_state_publisher when not fixed, which is just related to apt-install not accepting the key that changed on the ROS side. See comment in file.